### PR TITLE
Install Keystone Blueprint-export plugin

### DIFF
--- a/Plugins/KeystoneBlueprintExport/.gitignore
+++ b/Plugins/KeystoneBlueprintExport/.gitignore
@@ -1,0 +1,8 @@
+# The project root .gitignore blanket-ignores every Binaries/ and Intermediate/ folder.
+# For this editor plugin we deliberately DO commit the compiled editor module so artists
+# never have to recompile ("compile once, commit binaries" — the Keystone install flow).
+# Re-include only the runtime binaries; keep the heavy debug .pdb and all build
+# intermediates out of version control.
+!Binaries/
+Binaries/**/*.pdb
+Intermediate/

--- a/Plugins/KeystoneBlueprintExport/KeystoneBlueprintExport.uplugin
+++ b/Plugins/KeystoneBlueprintExport/KeystoneBlueprintExport.uplugin
@@ -1,0 +1,19 @@
+{
+  "FileVersion": 3,
+  "Version": 1,
+  "VersionName": "0.1.0",
+  "FriendlyName": "Keystone Blueprint Export",
+  "Description": "Exports each Blueprint's node graph to a committed .bpgraph.json so Keystone can render visual Blueprint diffs in merge requests. Editor-only; touches nothing at runtime.",
+  "Category": "Keystone",
+  "CreatedBy": "Keystone",
+  "CanContainContent": false,
+  "IsBetaVersion": true,
+  "Installed": false,
+  "Modules": [
+    {
+      "Name": "KeystoneBlueprintExport",
+      "Type": "Editor",
+      "LoadingPhase": "Default"
+    }
+  ]
+}

--- a/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/KeystoneBlueprintExport.Build.cs
+++ b/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/KeystoneBlueprintExport.Build.cs
@@ -1,0 +1,30 @@
+// Keystone Blueprint Export — editor module build rules. Editor-only (depends on UnrealEd
+// and BlueprintGraph), so it never links into a packaged game.
+using UnrealBuildTool;
+
+public class KeystoneBlueprintExport : ModuleRules
+{
+    public KeystoneBlueprintExport(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(new string[]
+        {
+            "Core",
+        });
+
+        PrivateDependencyModuleNames.AddRange(new string[]
+        {
+            "CoreUObject",
+            "Engine",
+            "Projects",          // IPluginManager, project paths
+            "Json",              // TJsonWriter
+            "UnrealEd",          // editor-only: UBlueprint access, save delegates, commandlet host
+            "BlueprintGraph",    // UK2Node, UEdGraph pins
+            "AssetRegistry",     // enumerate all Blueprints
+            "ToolMenus",         // the Keystone menu
+            "Slate",
+            "SlateCore",
+        });
+    }
+}

--- a/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneBlueprintExportModule.cpp
+++ b/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneBlueprintExportModule.cpp
@@ -1,0 +1,157 @@
+// Keystone Blueprint Export — editor module. Wires the exporter core to two of its three
+// triggers (the third, the commandlet, needs no module glue):
+//   • a Keystone menu with plain-language buttons (mirrors the source-art tool's menu), and
+//   • auto-capture on save (ON by default) so saving a Blueprint refreshes its .bpgraph.json
+//     with zero clicks — artists just work; the file stays current alongside their .uasset.
+//
+// On-save only *writes* the export next to the asset; pushing is left to the artist's normal
+// commit, the "Commit & Push" button, or the commandlet — so a save never forces a network push.
+#include "Modules/ModuleManager.h"
+#include "KeystoneBlueprintExporter.h"
+#include "KeystoneGit.h"
+
+#include "Engine/Blueprint.h"
+#include "UObject/Package.h"
+#include "UObject/UObjectHash.h"
+#include "UObject/ObjectSaveContext.h"
+#include "ToolMenus.h"
+#include "Misc/MessageDialog.h"
+
+#define LOCTEXT_NAMESPACE "Keystone"
+
+class FKeystoneBlueprintExportModule : public IModuleInterface
+{
+public:
+    virtual void StartupModule() override
+    {
+        UToolMenus::RegisterStartupCallback(
+            FSimpleMulticastDelegate::FDelegate::CreateStatic(&FKeystoneBlueprintExportModule::RegisterMenus));
+        SetAutoCapture(true); // "artists do nothing": capture on save is on out of the box
+    }
+
+    virtual void ShutdownModule() override
+    {
+        SetAutoCapture(false);
+        UToolMenus::UnRegisterStartupCallback(this);
+        if (UObjectInitialized()) UToolMenus::UnregisterOwner(MenuOwner());
+    }
+
+private:
+    static inline FDelegateHandle SaveHandle;
+
+    /** Stable owner for the menu we add, so register and unregister match (a name owner, not a
+     *  fabricated pointer — the latter doesn't convert to FToolMenuOwner in UE5.7). */
+    static FToolMenuOwner MenuOwner() { return FName("KeystoneBlueprintExport"); }
+
+    static bool IsAutoCaptureOn() { return SaveHandle.IsValid(); }
+
+    static void SetAutoCapture(bool bOn)
+    {
+        if (bOn && !SaveHandle.IsValid())
+        {
+            // UPackage::PackageSavedWithContextEvent — the post-save hook (UE5.0+). If your engine
+            // predates it, bind FEditorDelegates::OnPackageSaved instead.
+            SaveHandle = UPackage::PackageSavedWithContextEvent.AddStatic(&FKeystoneBlueprintExportModule::OnPackageSaved);
+        }
+        else if (!bOn && SaveHandle.IsValid())
+        {
+            UPackage::PackageSavedWithContextEvent.Remove(SaveHandle);
+            SaveHandle.Reset();
+        }
+    }
+
+    static void OnPackageSaved(const FString& /*PackageFilename*/, UPackage* Package, FObjectPostSaveContext /*Context*/)
+    {
+        if (!Package) return;
+        UBlueprint* BP = nullptr;
+        ForEachObjectWithPackage(Package, [&BP](UObject* Obj)
+        {
+            if (UBlueprint* B = Cast<UBlueprint>(Obj)) { BP = B; return false; }
+            return true;
+        });
+        if (!BP) return;
+        FKeystoneExportResult R;
+        FKeystoneBlueprintExporter::ExportOne(BP, R);
+    }
+
+    // ── menu ─────────────────────────────────────────────────────────────────
+    static void RegisterMenus()
+    {
+        FToolMenuOwnerScoped OwnerScoped(MenuOwner());
+        UToolMenu* MainMenu = UToolMenus::Get()->ExtendMenu("LevelEditor.MainMenu");
+        if (!MainMenu) return;
+        FToolMenuSection& Section = MainMenu->FindOrAddSection("Keystone");
+        Section.AddSubMenu(
+            "Keystone",
+            LOCTEXT("KeystoneMenu", "Keystone"),
+            LOCTEXT("KeystoneMenuTip", "Export Blueprint graphs for Keystone visual diffs"),
+            FNewToolMenuChoice(FNewToolMenuDelegate::CreateStatic(&FKeystoneBlueprintExportModule::BuildMenu)));
+    }
+
+    static void BuildMenu(UToolMenu* Menu)
+    {
+        FToolMenuSection& S = Menu->AddSection("KeystoneActions", LOCTEXT("KeystoneActions", "Blueprint Graphs"));
+        S.AddMenuEntry("ExportGraphs",
+            LOCTEXT("ExportGraphs", "Export Blueprint Graphs…"),
+            LOCTEXT("ExportGraphsTip", "Write every Blueprint's node graph to BlueprintGraphs/*.bpgraph.json"),
+            FSlateIcon(),
+            FUIAction(FExecuteAction::CreateStatic(&FKeystoneBlueprintExportModule::OnExportClicked)));
+        S.AddMenuEntry("CommitGraphs",
+            LOCTEXT("CommitGraphs", "Commit & Push Blueprint Graphs…"),
+            LOCTEXT("CommitGraphsTip", "Stage, commit and push only the BlueprintGraphs/ folder"),
+            FSlateIcon(),
+            FUIAction(FExecuteAction::CreateStatic(&FKeystoneBlueprintExportModule::OnCommitClicked)));
+        S.AddMenuEntry("ToggleAutoCapture",
+            LOCTEXT("ToggleAutoCapture", "Toggle Auto-Capture on Save"),
+            LOCTEXT("ToggleAutoCaptureTip", "Re-export a Blueprint's graph automatically whenever it's saved"),
+            FSlateIcon(),
+            FUIAction(
+                FExecuteAction::CreateStatic(&FKeystoneBlueprintExportModule::OnToggleAutoCapture),
+                FCanExecuteAction(),
+                FIsActionChecked::CreateStatic(&FKeystoneBlueprintExportModule::IsAutoCaptureOn)),
+            EUserInterfaceActionType::ToggleButton);
+    }
+
+    static void Info(const FString& Msg) { FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(Msg)); }
+    static bool Confirm(const FString& Msg) { return FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(Msg)) == EAppReturnType::Yes; }
+
+    static void OnExportClicked()
+    {
+        const FKeystoneExportResult R = FKeystoneBlueprintExporter::ExportAll();
+        FString Msg = FString::Printf(
+            TEXT("Exported Blueprint graphs.\n\nScanned: %d\nWritten/updated: %d\nUnchanged: %d"),
+            R.Scanned, R.Written, R.Unchanged);
+        if (R.Failed > 0) Msg += FString::Printf(TEXT("\nFailed: %d (see the Output Log)"), R.Failed);
+        Msg += TEXT("\n\nNext: Keystone ▸ Commit & Push Blueprint Graphs.");
+        Info(Msg);
+    }
+
+    static void OnCommitClicked()
+    {
+        if (!FKeystoneGit::Available())
+        {
+            Info(TEXT("Git isn't on this machine's PATH.\nCommit BlueprintGraphs/ with your usual git tool."));
+            return;
+        }
+        if (!Confirm(TEXT("Commit and push the BlueprintGraphs/ folder to the remote?\n\n(Only that path is staged — your other changes are untouched.)")))
+            return;
+        FString Err;
+        if (FKeystoneGit::CommitExports(TEXT("Update Keystone Blueprint graphs (automated)"), Err))
+            Info(TEXT("Blueprint graphs committed and pushed. Keystone will pick them up on its next sync."));
+        else
+            Info(Err);
+    }
+
+    static void OnToggleAutoCapture()
+    {
+        const bool bNext = !IsAutoCaptureOn();
+        SetAutoCapture(bNext);
+        Info(bNext
+            ? TEXT("Auto-capture ON — saving a Blueprint re-exports its graph automatically.")
+            : TEXT("Auto-capture OFF — export manually with Keystone ▸ Export Blueprint Graphs."));
+    }
+};
+
+#undef LOCTEXT_NAMESPACE
+
+IMPLEMENT_MODULE(FKeystoneBlueprintExportModule, KeystoneBlueprintExport)

--- a/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneBlueprintExporter.cpp
+++ b/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneBlueprintExporter.cpp
@@ -1,0 +1,305 @@
+#include "KeystoneBlueprintExporter.h"
+
+#include "Engine/Blueprint.h"
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNode.h"
+#include "EdGraph/EdGraphPin.h"
+#include "EdGraphNode_Comment.h"          // UEdGraphNode_Comment (module: UnrealEd)
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetRegistry/ARFilter.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "HAL/FileManager.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// The exporter reads the *live* editor model (UEdGraph/UEdGraphNode/UEdGraphPin) directly
+// rather than parsing the T3D copy/paste text — same full fidelity, but structured and far
+// less brittle across engine versions. Every value below maps 1:1 onto a field in the
+// `.bpgraph.json` schema (packages/types/src/blueprint-graph.ts).
+
+namespace
+{
+    using FJsonWriterRef = TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>>;
+
+    FString GuidStr(const FGuid& G)
+    {
+        return G.ToString(EGuidFormats::Digits).ToLower();
+    }
+
+    /** A pin's category + subtype flattened to a stable string, e.g. `exec`, `bool`,
+     *  `object:/Script/Engine.Actor`, `int[]`. Enough to diff a wire's type meaningfully. */
+    FString PinTypeString(const FEdGraphPinType& T)
+    {
+        FString S = T.PinCategory.ToString();
+        if (T.PinSubCategoryObject.IsValid())
+        {
+            S += TEXT(":") + T.PinSubCategoryObject->GetPathName();
+        }
+        else if (!T.PinSubCategory.IsNone())
+        {
+            S += TEXT(":") + T.PinSubCategory.ToString();
+        }
+        switch (T.ContainerType)
+        {
+            case EPinContainerType::Array: S += TEXT("[]"); break;
+            case EPinContainerType::Set:   S += TEXT("{}"); break;
+            case EPinContainerType::Map:   S += TEXT("{k:v}"); break;
+            default: break;
+        }
+        return S;
+    }
+
+    /** The literal on an unconnected input pin (a diffable value), or empty when the pin is
+     *  wired (its value comes from the wire, not a literal). */
+    FString PinDefault(const UEdGraphPin* P)
+    {
+        if (P->LinkedTo.Num() > 0) return FString();
+        if (P->DefaultObject) return P->DefaultObject->GetPathName();
+        if (!P->DefaultTextValue.IsEmpty()) return P->DefaultTextValue.ToString();
+        return P->DefaultValue;
+    }
+
+    // A pin's raw PinId GUID is NOT stable across editor loads — some nodes (e.g. math compare
+    // nodes' advanced `ErrorTolerance` pin) reconstruct pins on load and regenerate the GUID,
+    // which made re-exports churn. So identity is derived instead from the owning node's stable
+    // NodeGuid + the pin's direction + name (with an occurrence index when a node has duplicate
+    // names). Deterministic across loads, and it makes wire matching semantic rather than tied to
+    // a volatile GUID. `Seen` tracks per-(node,dir,name) counts across the whole graph.
+    FString StablePinId(UEdGraphNode* N, const UEdGraphPin* P, TMap<FString, int32>& Seen)
+    {
+        const FString Base = GuidStr(N->NodeGuid) + TEXT(":") +
+            (P->Direction == EGPD_Output ? TEXT("o:") : TEXT("i:")) + P->PinName.ToString();
+        int32& Count = Seen.FindOrAdd(Base);
+        const FString Id = Count == 0 ? Base : FString::Printf(TEXT("%s#%d"), *Base, Count);
+        ++Count;
+        return Id;
+    }
+
+    void WritePin(const FJsonWriterRef& W, const UEdGraphPin* P, const TMap<const UEdGraphPin*, FString>& PinIds)
+    {
+        W->WriteObjectStart();
+        W->WriteValue(TEXT("id"), PinIds[P]);
+        W->WriteValue(TEXT("name"), P->PinName.ToString());
+        W->WriteValue(TEXT("direction"), P->Direction == EGPD_Output ? TEXT("output") : TEXT("input"));
+        W->WriteValue(TEXT("type"), PinTypeString(P->PinType));
+        const FString Def = PinDefault(P);
+        if (Def.IsEmpty()) { W->WriteNull(TEXT("defaultValue")); }
+        else { W->WriteValue(TEXT("defaultValue"), Def); }
+
+        // Wire endpoints: the stable id of every pin this one connects to (links to pins outside
+        // this graph, or on skipped nodes, are dropped). Sorted for determinism.
+        TArray<FString> Links;
+        Links.Reserve(P->LinkedTo.Num());
+        for (const UEdGraphPin* L : P->LinkedTo)
+        {
+            if (const FString* Id = L ? PinIds.Find(L) : nullptr) Links.Add(*Id);
+        }
+        Links.Sort();
+        W->WriteArrayStart(TEXT("links"));
+        for (const FString& L : Links) W->WriteValue(L);
+        W->WriteArrayEnd();
+        W->WriteObjectEnd();
+    }
+
+    void WriteNode(const FJsonWriterRef& W, UEdGraphNode* N, const TMap<const UEdGraphPin*, FString>& PinIds)
+    {
+        W->WriteObjectStart();
+        W->WriteValue(TEXT("guid"), GuidStr(N->NodeGuid));
+        W->WriteValue(TEXT("class"), N->GetClass()->GetName());
+        W->WriteValue(TEXT("title"), N->GetNodeTitle(ENodeTitleType::ListView).ToString());
+        W->WriteValue(TEXT("x"), N->NodePosX);
+        W->WriteValue(TEXT("y"), N->NodePosY);
+        if (N->NodeComment.IsEmpty()) { W->WriteNull(TEXT("comment")); }
+        else { W->WriteValue(TEXT("comment"), N->NodeComment); }
+
+        // Native pin order (stable across loads, and the order pins appear on the node).
+        W->WriteArrayStart(TEXT("pins"));
+        for (const UEdGraphPin* P : N->Pins) { if (P) WritePin(W, P, PinIds); }
+        W->WriteArrayEnd();
+        W->WriteObjectEnd();
+    }
+
+    void WriteComment(const FJsonWriterRef& W, UEdGraphNode_Comment* C)
+    {
+        W->WriteObjectStart();
+        W->WriteValue(TEXT("guid"), GuidStr(C->NodeGuid));
+        W->WriteValue(TEXT("text"), C->NodeComment);
+        W->WriteValue(TEXT("x"), C->NodePosX);
+        W->WriteValue(TEXT("y"), C->NodePosY);
+        W->WriteValue(TEXT("width"), C->NodeWidth);
+        W->WriteValue(TEXT("height"), C->NodeHeight);
+        W->WriteObjectEnd();
+    }
+
+    void WriteGraph(const FJsonWriterRef& W, UEdGraph* G, const FString& Type)
+    {
+        W->WriteObjectStart();
+        W->WriteValue(TEXT("name"), G->GetName());
+        W->WriteValue(TEXT("type"), Type);
+
+        // Split comment boxes from real nodes; keep each list deterministically ordered.
+        TArray<UEdGraphNode*> Nodes;
+        TArray<UEdGraphNode_Comment*> Comments;
+        for (UEdGraphNode* N : G->Nodes)
+        {
+            if (!N) continue;
+            if (UEdGraphNode_Comment* C = Cast<UEdGraphNode_Comment>(N)) { Comments.Add(C); }
+            else { Nodes.Add(N); }
+        }
+        Nodes.Sort([](const UEdGraphNode& A, const UEdGraphNode& B) { return GuidStr(A.NodeGuid) < GuidStr(B.NodeGuid); });
+        Comments.Sort([](const UEdGraphNode_Comment& A, const UEdGraphNode_Comment& B) { return GuidStr(A.NodeGuid) < GuidStr(B.NodeGuid); });
+
+        // Assign every pin in the graph a stable id up front, so both a pin's own id and the
+        // link references pointing at it resolve to the same value.
+        TMap<const UEdGraphPin*, FString> PinIds;
+        TMap<FString, int32> Seen;
+        for (UEdGraphNode* N : Nodes)
+        {
+            for (const UEdGraphPin* P : N->Pins) { if (P) PinIds.Add(P, StablePinId(N, P, Seen)); }
+        }
+
+        W->WriteArrayStart(TEXT("nodes"));
+        for (UEdGraphNode* N : Nodes) WriteNode(W, N, PinIds);
+        W->WriteArrayEnd();
+
+        W->WriteArrayStart(TEXT("comments"));
+        for (UEdGraphNode_Comment* C : Comments) WriteComment(W, C);
+        W->WriteArrayEnd();
+
+        W->WriteObjectEnd();
+    }
+
+    /** Every graph of a Blueprint, tagged with its kind, in a stable order. */
+    void GatherGraphs(UBlueprint* BP, TArray<TPair<UEdGraph*, FString>>& Out)
+    {
+        for (UEdGraph* G : BP->UbergraphPages)        if (G) Out.Add({ G, TEXT("Ubergraph") });
+        for (UEdGraph* G : BP->FunctionGraphs)        if (G) Out.Add({ G, TEXT("Function") });
+        for (UEdGraph* G : BP->MacroGraphs)           if (G) Out.Add({ G, TEXT("Macro") });
+        for (UEdGraph* G : BP->DelegateSignatureGraphs) if (G) Out.Add({ G, TEXT("Delegate") });
+        Out.Sort([](const TPair<UEdGraph*, FString>& A, const TPair<UEdGraph*, FString>& B)
+        {
+            const FString KA = A.Value + TEXT(":") + A.Key->GetName();
+            const FString KB = B.Value + TEXT(":") + B.Key->GetName();
+            return KA < KB;
+        });
+    }
+}
+
+FString FKeystoneBlueprintExporter::BuildJson(UBlueprint* Blueprint)
+{
+    FString Out;
+    const FJsonWriterRef W = TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Out);
+
+    W->WriteObjectStart();
+    W->WriteValue(TEXT("version"), 1);
+    W->WriteValue(TEXT("generatedBy"), TEXT("keystone-blueprint-export"));
+    W->WriteValue(TEXT("package"), Blueprint->GetOutermost()->GetName()); // /Game/.../BP_Hero
+    W->WriteValue(TEXT("asset"), Blueprint->GetName());
+    if (Blueprint->ParentClass) { W->WriteValue(TEXT("parentClass"), Blueprint->ParentClass->GetName()); }
+    else { W->WriteNull(TEXT("parentClass")); }
+    W->WriteValue(TEXT("blueprintType"), StaticEnum<EBlueprintType>()->GetNameStringByValue(Blueprint->BlueprintType));
+
+    TArray<TPair<UEdGraph*, FString>> Graphs;
+    GatherGraphs(Blueprint, Graphs);
+    W->WriteArrayStart(TEXT("graphs"));
+    for (const TPair<UEdGraph*, FString>& GP : Graphs) WriteGraph(W, GP.Key, GP.Value);
+    W->WriteArrayEnd();
+
+    W->WriteObjectEnd();
+    W->Close();
+    return Out;
+}
+
+FString FKeystoneBlueprintExporter::ExportFileFor(UBlueprint* Blueprint)
+{
+    // /Game/Characters/BP_Hero  ->  <Project>/BlueprintGraphs/Characters/BP_Hero.bpgraph.json
+    FString Pkg = Blueprint->GetOutermost()->GetName();
+    FString Rel = Pkg;
+    if (Rel.StartsWith(TEXT("/Game/"))) { Rel = Rel.RightChop(6); }
+    else { Rel = Rel.TrimChar(TEXT('/')); }
+    const FString Abs = FPaths::Combine(FPaths::ProjectDir(), ExportSubdir(), Rel + TEXT(".bpgraph.json"));
+    return FPaths::ConvertRelativePathToFull(Abs);
+}
+
+bool FKeystoneBlueprintExporter::ExportOne(UBlueprint* Blueprint, FKeystoneExportResult& InOutResult)
+{
+    if (!Blueprint) { InOutResult.Failed++; return false; }
+    InOutResult.Scanned++;
+
+    const FString Json = BuildJson(Blueprint);
+    const FString File = ExportFileFor(Blueprint);
+
+    // Skip the write (and the git churn) when nothing changed.
+    FString Existing;
+    if (FFileHelper::LoadFileToString(Existing, *File) && Existing.Equals(Json, ESearchCase::CaseSensitive))
+    {
+        InOutResult.Unchanged++;
+        return true;
+    }
+    if (!FFileHelper::SaveStringToFile(Json, *File, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+    {
+        UE_LOG(LogTemp, Warning, TEXT("[keystone] failed to write %s"), *File);
+        InOutResult.Failed++;
+        return false;
+    }
+    InOutResult.Written++;
+    return true;
+}
+
+FKeystoneExportResult FKeystoneBlueprintExporter::ExportAll(const FString& RootPath)
+{
+    FKeystoneExportResult R;
+
+    FAssetRegistryModule& ARM = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+    FARFilter Filter;
+    Filter.ClassPaths.Add(UBlueprint::StaticClass()->GetClassPathName());
+    Filter.bRecursiveClasses = true;
+    Filter.PackagePaths.Add(*RootPath);
+    Filter.bRecursivePaths = true;
+
+    TArray<FAssetData> Assets;
+    ARM.Get().GetAssets(Filter, Assets);
+
+    // Manifest: package -> committed export path, so Keystone can resolve a changed .uasset to
+    // its .bpgraph.json without re-deriving the path rule.
+    FString ManifestJson;
+    const FJsonWriterRef MW = TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&ManifestJson);
+    MW->WriteObjectStart();
+    MW->WriteValue(TEXT("version"), 1);
+    MW->WriteValue(TEXT("generatedBy"), TEXT("keystone-blueprint-export"));
+    MW->WriteValue(TEXT("project"), FApp::GetProjectName());
+    MW->WriteArrayStart(TEXT("entries"));
+
+    Assets.Sort([](const FAssetData& A, const FAssetData& B) { return A.PackageName.LexicalLess(B.PackageName); });
+    for (const FAssetData& AD : Assets)
+    {
+        UBlueprint* BP = Cast<UBlueprint>(AD.GetAsset());
+        if (!BP) { R.Failed++; continue; }
+        ExportOne(BP, R);
+
+        const FString File = ExportFileFor(BP);
+        FString RepoRel = File;
+        FPaths::MakePathRelativeTo(RepoRel, *(FPaths::ProjectDir())); // e.g. BlueprintGraphs/Characters/BP_Hero.bpgraph.json
+        MW->WriteObjectStart();
+        MW->WriteValue(TEXT("package"), BP->GetOutermost()->GetName());
+        MW->WriteValue(TEXT("asset"), BP->GetName());
+        MW->WriteValue(TEXT("exportPath"), RepoRel);
+        MW->WriteObjectEnd();
+    }
+
+    MW->WriteArrayEnd();
+    MW->WriteObjectEnd();
+    MW->Close();
+
+    const FString ManifestFile = FPaths::ConvertRelativePathToFull(
+        FPaths::Combine(FPaths::ProjectDir(), ExportSubdir(), TEXT("keystone-blueprint-manifest.json")));
+    if (FFileHelper::SaveStringToFile(ManifestJson, *ManifestFile, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+    {
+        R.ManifestPath = ManifestFile;
+    }
+
+    UE_LOG(LogTemp, Log, TEXT("[keystone] export: scanned=%d written=%d unchanged=%d failed=%d"),
+        R.Scanned, R.Written, R.Unchanged, R.Failed);
+    return R;
+}

--- a/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneBlueprintExporter.h
+++ b/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneBlueprintExporter.h
@@ -1,0 +1,44 @@
+// Keystone Blueprint Exporter — the core, shared by every trigger (menu button, on-save
+// hook, and the headless commandlet). Turns a UBlueprint's live graphs into the deterministic
+// `.bpgraph.json` that Keystone reads to render a visual MR diff. No UI, no git here — just
+// "Blueprint in, JSON file(s) out" so it's trivial to call from anywhere and reason about.
+#pragma once
+
+#include "CoreMinimal.h"
+
+class UBlueprint;
+
+/** Counts returned from a sweep, so callers (menu/commandlet) can report what happened. */
+struct FKeystoneExportResult
+{
+    int32 Scanned = 0;   // Blueprints examined
+    int32 Written = 0;   // .bpgraph.json files created or updated
+    int32 Unchanged = 0; // already up to date (byte-identical) — skipped
+    int32 Failed = 0;    // load/serialize errors
+    FString ManifestPath; // repo-relative path of the manifest written, or empty
+};
+
+class FKeystoneBlueprintExporter
+{
+public:
+    /** Project-relative folder the exports are written under (sibling of Content/). */
+    static const TCHAR* ExportSubdir() { return TEXT("BlueprintGraphs"); }
+
+    /** Serialize one Blueprint's every graph to the `.bpgraph.json` shape. Pure — returns the
+     *  JSON string; does not touch disk. Deterministic ordering (graphs/nodes/pins sorted by a
+     *  stable key) so re-exports produce byte-identical output and git diffs stay minimal. */
+    static FString BuildJson(UBlueprint* Blueprint);
+
+    /** Absolute path the export for `Blueprint` is written to, e.g.
+     *  `<Project>/BlueprintGraphs/Characters/BP_Hero.bpgraph.json`. Mirrors the package path
+     *  under /Game so a .uasset maps to its export by a deterministic rule (plus the manifest). */
+    static FString ExportFileFor(UBlueprint* Blueprint);
+
+    /** Export a single Blueprint to disk (only rewrites if the JSON actually changed). Updates
+     *  `InOutResult`. Used by the on-save hook for one asset. */
+    static bool ExportOne(UBlueprint* Blueprint, FKeystoneExportResult& InOutResult);
+
+    /** Sweep every Blueprint under `RootPath` (default /Game), export each, and (re)write the
+     *  manifest that lists them. Used by the menu backfill and the commandlet. */
+    static FKeystoneExportResult ExportAll(const FString& RootPath = TEXT("/Game"));
+};

--- a/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneExportBlueprintsCommandlet.cpp
+++ b/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneExportBlueprintsCommandlet.cpp
@@ -1,0 +1,35 @@
+#include "KeystoneExportBlueprintsCommandlet.h"
+
+#include "KeystoneBlueprintExporter.h"
+#include "KeystoneGit.h"
+
+int32 UKeystoneExportBlueprintsCommandlet::Main(const FString& Params)
+{
+    TArray<FString> Tokens, Switches;
+    TMap<FString, FString> ParamVals;
+    ParseCommandLine(*Params, Tokens, Switches, ParamVals);
+
+    const FString Root = ParamVals.Contains(TEXT("path")) ? ParamVals[TEXT("path")] : TEXT("/Game");
+    UE_LOG(LogTemp, Display, TEXT("[keystone] commandlet exporting Blueprints under %s"), *Root);
+
+    const FKeystoneExportResult R = FKeystoneBlueprintExporter::ExportAll(Root);
+    UE_LOG(LogTemp, Display, TEXT("[keystone] scanned=%d written=%d unchanged=%d failed=%d"),
+        R.Scanned, R.Written, R.Unchanged, R.Failed);
+
+    if (Switches.Contains(TEXT("commit")))
+    {
+        FString Err;
+        if (FKeystoneGit::CommitExports(TEXT("Update Keystone Blueprint graphs (automated)"), Err))
+        {
+            UE_LOG(LogTemp, Display, TEXT("[keystone] committed + pushed Blueprint graphs"));
+        }
+        else
+        {
+            // "nothing to commit" is normal (nothing changed) — warn, don't fail the run.
+            UE_LOG(LogTemp, Warning, TEXT("[keystone] commit skipped: %s"), *Err);
+        }
+    }
+
+    // Non-zero only on genuine export failures, so CI can gate on it.
+    return R.Failed > 0 ? 1 : 0;
+}

--- a/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneExportBlueprintsCommandlet.h
+++ b/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneExportBlueprintsCommandlet.h
@@ -1,0 +1,21 @@
+// Headless export — the "artists do nothing" path. Keystone (or CI) runs this on a build
+// agent that has the engine + a checkout of the project:
+//
+//   UnrealEditor-Cmd <Project>.uproject -run=KeystoneExportBlueprints [-commit] [-path=/Game/...]
+//
+// It exports every Blueprint to `.bpgraph.json` and, with -commit, stages+commits+pushes just
+// the BlueprintGraphs/ folder. No editor UI, no artist involvement.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Commandlets/Commandlet.h"
+#include "KeystoneExportBlueprintsCommandlet.generated.h"
+
+UCLASS()
+class UKeystoneExportBlueprintsCommandlet : public UCommandlet
+{
+    GENERATED_BODY()
+
+public:
+    virtual int32 Main(const FString& Params) override;
+};

--- a/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneGit.cpp
+++ b/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneGit.cpp
@@ -1,0 +1,78 @@
+#include "KeystoneGit.h"
+
+#include "KeystoneBlueprintExporter.h"
+#include "Misc/Paths.h"
+#include "Misc/MonitoredProcess.h"
+#include "HAL/PlatformProcess.h"
+
+int32 FKeystoneGit::Run(const FString& Args, const FString& WorkingDir, FString& Out)
+{
+    int32 ReturnCode = -1;
+    FString StdOut, StdErr;
+    // Blocking process capture — export/commit runs are short and user-initiated.
+    const bool bLaunched = FPlatformProcess::ExecProcess(
+        TEXT("git"), *Args, &ReturnCode, &StdOut, &StdErr, *WorkingDir);
+    Out = StdOut + StdErr;
+    if (!bLaunched)
+    {
+        Out = TEXT("could not launch git (is it on PATH?)");
+        return -1;
+    }
+    return ReturnCode;
+}
+
+bool FKeystoneGit::Available()
+{
+    FString Out;
+    return Run(TEXT("--version"), FPaths::ProjectDir(), Out) == 0;
+}
+
+FString FKeystoneGit::RepoRoot()
+{
+    FString Out;
+    if (Run(TEXT("rev-parse --show-toplevel"), FPaths::ConvertRelativePathToFull(FPaths::ProjectDir()), Out) == 0)
+    {
+        return Out.TrimStartAndEnd();
+    }
+    return FString();
+}
+
+bool FKeystoneGit::CommitExports(const FString& Message, FString& OutError)
+{
+    const FString Root = RepoRoot();
+    if (Root.IsEmpty())
+    {
+        OutError = TEXT("This project isn't in a git working tree — commit BlueprintGraphs/ with your usual tool.");
+        return false;
+    }
+
+    // Path to the export folder, relative to the repo root (project may be a subdir of the repo).
+    FString ExportAbs = FPaths::ConvertRelativePathToFull(
+        FPaths::Combine(FPaths::ProjectDir(), FKeystoneBlueprintExporter::ExportSubdir()));
+    FString ExportRel = ExportAbs;
+    FPaths::MakePathRelativeTo(ExportRel, *(Root / TEXT("")));
+
+    FString Out;
+    if (Run(FString::Printf(TEXT("add -- \"%s\""), *ExportRel), Root, Out) != 0)
+    {
+        OutError = FString::Printf(TEXT("git add failed: %s"), *Out.Left(800));
+        return false;
+    }
+    const int32 CommitCode = Run(FString::Printf(TEXT("commit -m \"%s\""), *Message), Root, Out);
+    if (CommitCode != 0)
+    {
+        if (Out.ToLower().Contains(TEXT("nothing to commit")))
+        {
+            OutError = TEXT("Nothing new to commit — Blueprint graphs are already up to date.");
+            return false;
+        }
+        OutError = FString::Printf(TEXT("git commit failed: %s"), *Out.Left(800));
+        return false;
+    }
+    if (Run(TEXT("push"), Root, Out) != 0)
+    {
+        OutError = FString::Printf(TEXT("git push failed: %s"), *Out.Left(800));
+        return false;
+    }
+    return true;
+}

--- a/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneGit.h
+++ b/Plugins/KeystoneBlueprintExport/Source/KeystoneBlueprintExport/Private/KeystoneGit.h
@@ -1,0 +1,23 @@
+// Tiny git shell helper, shared by the menu button and the commandlet. Mirrors the source-art
+// tool's plumbing (tools/unreal-source-sync/keystone_menu.py): stage ONLY the export folder,
+// commit, push — never the artist's other changes. Best-effort; failures are reported, not fatal.
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FKeystoneGit
+{
+public:
+    /** Run `git <Args>` in `WorkingDir`. Returns the exit code; combined stdout+stderr in Out. */
+    static int32 Run(const FString& Args, const FString& WorkingDir, FString& Out);
+
+    /** True if a git executable is reachable on PATH. */
+    static bool Available();
+
+    /** Repo root containing the project, or empty if this isn't a git working tree. */
+    static FString RepoRoot();
+
+    /** Stage just `BlueprintGraphs/`, commit with `Message`, and push. Returns false (with a
+     *  human-readable reason in OutError) on any failure, including "nothing to commit". */
+    static bool CommitExports(const FString& Message, FString& OutError);
+};

--- a/ProjectAtlantis.uproject
+++ b/ProjectAtlantis.uproject
@@ -21,6 +21,10 @@
 			"TargetAllowList": [
 				"Editor"
 			]
+		},
+		{
+			"Name": "KeystoneBlueprintExport",
+			"Enabled": true
 		}
 	],
 	"TargetPlatforms": [


### PR DESCRIPTION
## Keystone Blueprint-export plugin

Opened automatically from Keystone. This change:

- adds the **KeystoneBlueprintExport** C++ editor plugin under `Plugins/`
- enables it in the `.uproject`

The plugin is **editor-only** — it never links into a packaged/shipping build.

### One-time compile, then artists do nothing

1. On **one** machine that has the engine + a C++ toolchain, open the project and accept the
   "rebuild modules?" prompt (or build from your IDE).
2. Commit the plugin folder — the shipped `Plugins/KeystoneBlueprintExport/.gitignore` already
   re-includes the compiled `Binaries/` (the project root normally ignores them) while keeping
   the heavy `.pdb` symbols and `Intermediate/` out. So a plain `git add Plugins/KeystoneBlueprintExport`
   picks up the `.dll` + `.modules` and nothing else.
3. Everyone else just pulls — no compiler needed.

_Caveat: committed binaries load without recompiling only when the team shares the same
launcher-installed engine build. A different engine version/hotfix will trigger a one-time
rebuild on that machine (re-commit the new binaries)._

Each Blueprint’s node graph is exported to a committed `BlueprintGraphs/*.bpgraph.json`
(on save, from the **Keystone** menu, or via the headless `-run=KeystoneExportBlueprints` commandlet),
so Keystone can show a **visual diff** of Blueprint changes in merge requests.

_Review the files before merging — nothing else in the project is touched._