### PR TITLE
Add GameAnalytics plugin dependency to build script

### DIFF
--- a/Source/ProjectAtlantis/ProjectAtlantis.Build.cs
+++ b/Source/ProjectAtlantis/ProjectAtlantis.Build.cs
@@ -10,7 +10,9 @@ public class ProjectAtlantis : ModuleRules
 	
 		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore" });
 
-		PrivateDependencyModuleNames.AddRange(new string[] {  });
+		PrivateDependencyModuleNames.AddRange(new string[] { "GameAnalytics" });
+
+		PrivateIncludePathModuleNames.AddRange(new string[] { "GameAnalytics" });
 
 		// Uncomment if you are using Slate UI
 		// PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });


### PR DESCRIPTION
# Summary

The binary build for [0.0.2](../../releases/tag/0.0.2) has been marked as identical to 0.0.1 by Steam during upload. This appears to be due to not including the GameAnalytics plugin as a build dependency.

Reference: https://docs.gameanalytics.com/event-tracking-and-integrations/sdks-and-collection-api/game-engine-sdks/unreal/#using-gameanalytics-from-c

# Related Issue

Related to #40

# Testing

- [x] Built successfully
- [x] Tested locally
- [x] No known regressions

# Checklist

- [x] PR title accurately summarizes the final change
- [x] Summary reflects what was actually implemented
- [x] Follows the project style guide
- [x] Documentation updated if needed
- [x] No unrelated changes included
- [x] Ready for review


