### PR TITLE
Make sure JSON files from Keystone plugin use LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,3 +25,6 @@
 
 # Keystone source-art (LFS)
 SourceArt/**/*.png filter=lfs diff=lfs merge=lfs -text
+
+# Keystone BP sourcefiles
+*.json text eol=lf


### PR DESCRIPTION
# Summary

Make sure JSON files from Keystone plugin use LF line endings - otherwise the packaging process will generate a lot of odd diffs in the JSON files as they try to convert to CRLF.

# Related Issue
Related to: #42, #43

# Testing

- [x] Built successfully
- [x] Tested locally
- [x] No known regressions

# Checklist

- [x] PR title accurately summarizes the final change
- [x] Summary reflects what was actually implemented
- [x] Follows the project style guide
- [x] Documentation updated if needed
- [x] No unrelated changes included
- [x] Ready for review
