### PR TITLE
Add Gitea 2FA setup guide and update documentation references

### DIFF
--- a/Docs/Gitea 2FA.md
+++ b/Docs/Gitea 2FA.md
@@ -1,0 +1,100 @@
+# In Case You Enabled 2FA on Gitea
+
+For initial setup, cloning, and project requirements, see [SETUP.md](./SETUP.md)
+
+**Note**: Ignore this guide if Gitea 2FA is disabled.
+
+If you enable 2FA on Gitea, plain username/password authentication over HTTPS
+(used by Git and Git LFS) stops working. Instead, generate an access token and
+store it as your Git credential.
+
+1. Create an access token in the [Applications](https://asgc.freemyip.com/user/settings/applications)
+   settings tab via the [user interface](https://docs.gitea.com/development/api-usage/#user-interface).
+2. Store the token as your Git credential, then immediately verify it was
+   stored, using the commands for your shell below. Replace
+   `your-gitea-username` and `your-personal-access-token` with your actual
+   values.
+
+Bash (WSL / Git Bash):
+
+```bash
+printf "protocol=https\nhost=asgc.freemyip.com\nusername=your-gitea-username\npassword=your-personal-access-token\n\n" | git credential approve
+printf "protocol=https\nhost=asgc.freemyip.com\n\n" | git credential fill
+```
+
+PowerShell:
+
+```powershell
+@"
+protocol=https
+host=asgc.freemyip.com
+username=your-gitea-username
+password=your-personal-access-token
+
+"@ | git credential approve
+
+@"
+protocol=https
+host=asgc.freemyip.com
+
+"@ | git credential fill
+```
+
+Both end with `git credential fill`, which should immediately print your
+stored credential back without prompting:
+
+```text
+protocol=https
+host=asgc.freemyip.com
+username=your-gitea-username
+password=your-personal-access-token
+```
+
+This prints your token in plain text, so run it somewhere private and clear
+your scrollback afterward.
+
+## Do WSL and PowerShell Share the Same Credential?
+
+They can, depending on how WSL's Git is configured. Check both:
+
+```
+git config --show-origin --get-all credential.helper
+```
+
+Example:
+```
+PS C:\Dev\asgc-gamejam-2026> git config --show-origin --get-all credential.helper
+file:C:/Program Files/Git/etc/gitconfig manager
+file:C:/Users/dulta/.gitconfig  manager
+PS C:\Dev\asgc-gamejam-2026> wsl
+To run a command as administrator (user "root"), use "sudo <command>".
+See "man sudo_root" for details.
+
+dulta@Dansktop:/mnt/c/Dev/asgc-gamejam-2026$ git config --show-origin --get-all credential.helper
+file:/home/dulta/.gitconfig     /mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe
+dulta@Dansktop:/mnt/c/Dev/asgc-gamejam-2026$ 
+```
+
+- **If WSL's helper points at the Windows GCM executable** (something like
+  `/mnt/c/Program Files/Git/mingw64/bin/git-credential-manager.exe`), WSL
+  isn't using a separate Linux credential store — it's invoking the same
+  Windows binary PowerShell uses, which reads and writes the same Windows
+  Credential Manager entry. Storing the token once from either shell covers
+  both, and rejecting/updating it in one is immediately visible in the other.
+- **If WSL's helper is something else** (`store`, `cache`, `libsecret`, or
+  unset), WSL keeps its own independent credential store and you need to
+  store the token separately in each shell.
+
+To point WSL at the Windows store, set:
+
+```bash
+git config --global credential.helper "/mnt/c/Program Files/Git/mingw64/bin/git-credential-manager.exe"
+```
+
+A couple of caveats even when sharing is set up:
+
+- Entries are keyed by `protocol` and `host` (and `path`, if
+  `credential.useHttpPath` is set), so both shells need to hit the exact same
+  host string (`asgc.freemyip.com`) to see the same entry.
+- This only applies to HTTPS. If either shell clones or pushes over SSH,
+  credential storage isn't involved — SSH uses keys instead.

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -3,3 +3,4 @@
 ## Getting Started
 
 - Read [SETUP.md](./SETUP.md) to get your development environment read
+- If you enabled 2FA on Gitea, see [Gitea 2FA.md](./Gitea%202FA.md)

--- a/Docs/SETUP.md
+++ b/Docs/SETUP.md
@@ -7,13 +7,12 @@ ASGC Game Jam 2026 project
 
 Install the following before cloning the repository
 
-- Git
+- [Git](https://git-scm.com/install/)
 - [Git LFS](https://git-lfs.com/)
 - Unreal Engine 5.7.4
-- Visual Studio 2022 (or another IDE configured for Unreal Engine C++ development)
-  - MSVC
-  - Windows SDK
-  - C++ profiling tools (recommended)
+- [Visual Studio 2022](https://visualstudio.microsoft.com/vs/older-downloads/) or [Rider](https://www.jetbrains.com/rider/download/) (or another IDE configured for Unreal Engine C++ development)
+  - [Setting up Visual Studio](https://dev.epicgames.com/documentation/unreal-engine/setting-up-visual-studio-development-environment-for-cplusplus-projects-in-unreal-engine)
+  - [Setting up Rider](https://tomlooman.com/setup-unreal-engine-cpp-rider/)
 
 Verify Git LFS is installed
 
@@ -114,3 +113,9 @@ Once your environment is working
 - Create a feature branch
 - Lock shared binary assets before editing them
 - Start building
+
+## In Case You Enabled 2FA on Gitea
+
+If you enabled 2FA on Gitea, plain username/password Git authentication stops
+working. See [Gitea 2FA.md](./Gitea%202FA.md) for how to set up an access
+token instead, for both Bash (WSL) and PowerShell.


### PR DESCRIPTION
# Summary

Add setup guide and update documentation references showing how to auth with Gitea when 2FA is enabled.

# Related Issue
n/a

# Testing

- [x] Built successfully
- [x] Tested locally
- [x] No known regressions

# Checklist

- [x] PR title accurately summarizes the final change
- [x] Summary reflects what was actually implemented
- [x] Follows the project style guide
- [x] Documentation updated if needed
- [x] No unrelated changes included
- [x] Ready for review
