### PR TITLE
Add scene performance analytics tracking

### DIFF
--- a/BlueprintGraphs/ProjectAtlantis/Maps/Lvl_ThirdPerson.bpgraph.json
+++ b/BlueprintGraphs/ProjectAtlantis/Maps/Lvl_ThirdPerson.bpgraph.json
@@ -11,100 +11,6 @@
 			"type": "Ubergraph",
 			"nodes": [
 				{
-					"guid": "1e1d47a745623983b375eaa74960c7eb",
-					"class": "K2Node_CallFunction",
-					"title": "Print String",
-					"x": 768,
-					"y": 176,
-					"comment": null,
-					"pins": [
-						{
-							"id": "1e1d47a745623983b375eaa74960c7eb:i:execute",
-							"name": "execute",
-							"direction": "input",
-							"type": "exec",
-							"defaultValue": null,
-							"links": [
-								"a7ad20de4abe8456f8b014a961fd43d6:o:else"
-							]
-						},
-						{
-							"id": "1e1d47a745623983b375eaa74960c7eb:o:then",
-							"name": "then",
-							"direction": "output",
-							"type": "exec",
-							"defaultValue": null,
-							"links": [
-								"c70bd77b4e12ed004d13cea31a8f0174:i:execute"
-							]
-						},
-						{
-							"id": "1e1d47a745623983b375eaa74960c7eb:i:self",
-							"name": "self",
-							"direction": "input",
-							"type": "object:/Script/Engine.KismetSystemLibrary",
-							"defaultValue": "/Script/Engine.Default__KismetSystemLibrary",
-							"links": []
-						},
-						{
-							"id": "1e1d47a745623983b375eaa74960c7eb:i:WorldContextObject",
-							"name": "WorldContextObject",
-							"direction": "input",
-							"type": "object:/Script/CoreUObject.Object",
-							"defaultValue": null,
-							"links": []
-						},
-						{
-							"id": "1e1d47a745623983b375eaa74960c7eb:i:InString",
-							"name": "InString",
-							"direction": "input",
-							"type": "string",
-							"defaultValue": "Analytics Failed to Start",
-							"links": []
-						},
-						{
-							"id": "1e1d47a745623983b375eaa74960c7eb:i:bPrintToScreen",
-							"name": "bPrintToScreen",
-							"direction": "input",
-							"type": "bool",
-							"defaultValue": "true",
-							"links": []
-						},
-						{
-							"id": "1e1d47a745623983b375eaa74960c7eb:i:bPrintToLog",
-							"name": "bPrintToLog",
-							"direction": "input",
-							"type": "bool",
-							"defaultValue": "true",
-							"links": []
-						},
-						{
-							"id": "1e1d47a745623983b375eaa74960c7eb:i:TextColor",
-							"name": "TextColor",
-							"direction": "input",
-							"type": "struct:/Script/CoreUObject.LinearColor",
-							"defaultValue": "(R=0.660000,G=0.000000,B=0.000000,A=1.000000)",
-							"links": []
-						},
-						{
-							"id": "1e1d47a745623983b375eaa74960c7eb:i:Duration",
-							"name": "Duration",
-							"direction": "input",
-							"type": "real:float",
-							"defaultValue": "2.000000",
-							"links": []
-						},
-						{
-							"id": "1e1d47a745623983b375eaa74960c7eb:i:Key",
-							"name": "Key",
-							"direction": "input",
-							"type": "name",
-							"defaultValue": "None",
-							"links": []
-						}
-					]
-				},
-				{
 					"guid": "445ac30945752fad03fe51a3c920a7c8",
 					"class": "K2Node_Event",
 					"title": "Event BeginPlay",
@@ -127,55 +33,7 @@
 							"type": "exec",
 							"defaultValue": null,
 							"links": [
-								"5328a30541f1a99e927e04a31ebbc666:i:execute"
-							]
-						}
-					]
-				},
-				{
-					"guid": "5328a30541f1a99e927e04a31ebbc666",
-					"class": "K2Node_CallFunction",
-					"title": "Start Session",
-					"x": 320,
-					"y": 0,
-					"comment": null,
-					"pins": [
-						{
-							"id": "5328a30541f1a99e927e04a31ebbc666:i:execute",
-							"name": "execute",
-							"direction": "input",
-							"type": "exec",
-							"defaultValue": null,
-							"links": [
-								"445ac30945752fad03fe51a3c920a7c8:o:then"
-							]
-						},
-						{
-							"id": "5328a30541f1a99e927e04a31ebbc666:o:then",
-							"name": "then",
-							"direction": "output",
-							"type": "exec",
-							"defaultValue": null,
-							"links": [
-								"a7ad20de4abe8456f8b014a961fd43d6:i:execute"
-							]
-						},
-						{
-							"id": "5328a30541f1a99e927e04a31ebbc666:i:self",
-							"name": "self",
-							"direction": "input",
-							"type": "object:/Script/AnalyticsBlueprintLibrary.AnalyticsBlueprintLibrary",
-							"defaultValue": "/Script/AnalyticsBlueprintLibrary.Default__AnalyticsBlueprintLibrary",
-							"links": []
-						},
-						{
-							"id": "5328a30541f1a99e927e04a31ebbc666:o:ReturnValue",
-							"name": "ReturnValue",
-							"direction": "output",
-							"type": "bool",
-							"defaultValue": null,
-							"links": [
-								"a7ad20de4abe8456f8b014a961fd43d6:i:Condition"
+								"c70bd77b4e12ed004d13cea31a8f0174:i:execute"
 							]
 						}
 					]
@@ -295,56 +153,6 @@
 					]
 				},
 				{
-					"guid": "a7ad20de4abe8456f8b014a961fd43d6",
-					"class": "K2Node_IfThenElse",
-					"title": "Branch",
-					"x": 512,
-					"y": 0,
-					"comment": null,
-					"pins": [
-						{
-							"id": "a7ad20de4abe8456f8b014a961fd43d6:i:execute",
-							"name": "execute",
-							"direction": "input",
-							"type": "exec",
-							"defaultValue": null,
-							"links": [
-								"5328a30541f1a99e927e04a31ebbc666:o:then"
-							]
-						},
-						{
-							"id": "a7ad20de4abe8456f8b014a961fd43d6:i:Condition",
-							"name": "Condition",
-							"direction": "input",
-							"type": "bool",
-							"defaultValue": null,
-							"links": [
-								"5328a30541f1a99e927e04a31ebbc666:o:ReturnValue"
-							]
-						},
-						{
-							"id": "a7ad20de4abe8456f8b014a961fd43d6:o:then",
-							"name": "then",
-							"direction": "output",
-							"type": "exec",
-							"defaultValue": null,
-							"links": [
-								"e3810b7d4ca609fb4328bd8f9bf23ecd:i:execute"
-							]
-						},
-						{
-							"id": "a7ad20de4abe8456f8b014a961fd43d6:o:else",
-							"name": "else",
-							"direction": "output",
-							"type": "exec",
-							"defaultValue": null,
-							"links": [
-								"1e1d47a745623983b375eaa74960c7eb:i:execute"
-							]
-						}
-					]
-				},
-				{
 					"guid": "c70bd77b4e12ed004d13cea31a8f0174",
 					"class": "K2Node_CreateWidget",
 					"title": "Create Widget",
@@ -359,8 +167,7 @@
 							"type": "exec",
 							"defaultValue": null,
 							"links": [
-								"1e1d47a745623983b375eaa74960c7eb:o:then",
-								"e3810b7d4ca609fb4328bd8f9bf23ecd:o:then"
+								"445ac30945752fad03fe51a3c920a7c8:o:then"
 							]
 						},
 						{
@@ -397,100 +204,6 @@
 							"direction": "input",
 							"type": "object:/Script/Engine.PlayerController",
 							"defaultValue": null,
-							"links": []
-						}
-					]
-				},
-				{
-					"guid": "e3810b7d4ca609fb4328bd8f9bf23ecd",
-					"class": "K2Node_CallFunction",
-					"title": "Print String",
-					"x": 768,
-					"y": 0,
-					"comment": null,
-					"pins": [
-						{
-							"id": "e3810b7d4ca609fb4328bd8f9bf23ecd:i:execute",
-							"name": "execute",
-							"direction": "input",
-							"type": "exec",
-							"defaultValue": null,
-							"links": [
-								"a7ad20de4abe8456f8b014a961fd43d6:o:then"
-							]
-						},
-						{
-							"id": "e3810b7d4ca609fb4328bd8f9bf23ecd:o:then",
-							"name": "then",
-							"direction": "output",
-							"type": "exec",
-							"defaultValue": null,
-							"links": [
-								"c70bd77b4e12ed004d13cea31a8f0174:i:execute"
-							]
-						},
-						{
-							"id": "e3810b7d4ca609fb4328bd8f9bf23ecd:i:self",
-							"name": "self",
-							"direction": "input",
-							"type": "object:/Script/Engine.KismetSystemLibrary",
-							"defaultValue": "/Script/Engine.Default__KismetSystemLibrary",
-							"links": []
-						},
-						{
-							"id": "e3810b7d4ca609fb4328bd8f9bf23ecd:i:WorldContextObject",
-							"name": "WorldContextObject",
-							"direction": "input",
-							"type": "object:/Script/CoreUObject.Object",
-							"defaultValue": null,
-							"links": []
-						},
-						{
-							"id": "e3810b7d4ca609fb4328bd8f9bf23ecd:i:InString",
-							"name": "InString",
-							"direction": "input",
-							"type": "string",
-							"defaultValue": "Analytics Started",
-							"links": []
-						},
-						{
-							"id": "e3810b7d4ca609fb4328bd8f9bf23ecd:i:bPrintToScreen",
-							"name": "bPrintToScreen",
-							"direction": "input",
-							"type": "bool",
-							"defaultValue": "true",
-							"links": []
-						},
-						{
-							"id": "e3810b7d4ca609fb4328bd8f9bf23ecd:i:bPrintToLog",
-							"name": "bPrintToLog",
-							"direction": "input",
-							"type": "bool",
-							"defaultValue": "true",
-							"links": []
-						},
-						{
-							"id": "e3810b7d4ca609fb4328bd8f9bf23ecd:i:TextColor",
-							"name": "TextColor",
-							"direction": "input",
-							"type": "struct:/Script/CoreUObject.LinearColor",
-							"defaultValue": "(R=0.000000,G=0.660000,B=0.000000,A=1.000000)",
-							"links": []
-						},
-						{
-							"id": "e3810b7d4ca609fb4328bd8f9bf23ecd:i:Duration",
-							"name": "Duration",
-							"direction": "input",
-							"type": "real:float",
-							"defaultValue": "2.000000",
-							"links": []
-						},
-						{
-							"id": "e3810b7d4ca609fb4328bd8f9bf23ecd:i:Key",
-							"name": "Key",
-							"direction": "input",
-							"type": "name",
-							"defaultValue": "None",
 							"links": []
 						}
 					]

--- a/Content/ProjectAtlantis/Maps/Lvl_ThirdPerson.umap
+++ b/Content/ProjectAtlantis/Maps/Lvl_ThirdPerson.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae5cd31a5ff661bcece4f1c82cf3c4811d5cd68494d1bfe2679d3928513fa025
-size 63982
+oid sha256:604207ae8fb398f57f0a9703a4967199619f6744e4b6132f03e6656079eb38d6
+size 46898

--- a/Source/ProjectAtlantis/Private/Analytics/ScenePerformanceAnalyticsSubsystem.cpp
+++ b/Source/ProjectAtlantis/Private/Analytics/ScenePerformanceAnalyticsSubsystem.cpp
@@ -3,6 +3,8 @@
 #include "Engine/Engine.h"
 #include "Engine/World.h"
 #include "GameAnalytics.h"
+#include "Analytics.h"
+#include "Interfaces/IAnalyticsProvider.h"
 #include "HAL/PlatformTime.h"
 #include "Misc/PackageName.h"
 #include "UObject/UObjectGlobals.h"
@@ -13,6 +15,26 @@ void UScenePerformanceAnalyticsSubsystem::Initialize(FSubsystemCollectionBase& C
 {
 	Super::Initialize(Collection);
 	GameInstanceStartSeconds = FPlatformTime::Seconds();
+
+#if !WITH_EDITOR
+
+	if (TSharedPtr<IAnalyticsProvider> AnalyticsProvider = FAnalytics::Get().GetDefaultConfiguredProvider())
+	{
+		if (AnalyticsProvider->StartSession())
+		{
+			UE_LOG(LogScenePerformanceAnalytics, Display, TEXT("GameAnalytics session started"));
+		}
+		else
+		{
+			UE_LOG(LogScenePerformanceAnalytics, Warning, TEXT("GameAnalytics session failed to start"));
+		}
+	}
+	else
+	{
+		UE_LOG(LogScenePerformanceAnalytics, Warning, TEXT("GameAnalytics provider unavailable"));
+	}
+#endif
+
 	PreLoadMapHandle = FCoreUObjectDelegates::PreLoadMapWithContext.AddUObject (this, &UScenePerformanceAnalyticsSubsystem::HandlePreLoadMap);
 	PostLoadMapHandle = FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject (this, &UScenePerformanceAnalyticsSubsystem::HandlePostLoadMap);
 	WorldPostActorTickHandle = FWorldDelegates::OnWorldPostActorTick.AddUObject(this, &UScenePerformanceAnalyticsSubsystem::HandleWorldPostActorTick);
@@ -126,6 +148,7 @@ void UScenePerformanceAnalyticsSubsystem::SubmitTiming(const FString& EventId, f
 		return;
 
 #if !WITH_EDITOR
+
 	if (UGameAnalytics* GameAnalytics = UGameAnalytics::GetInstance())
 		GameAnalytics->AddDesignEventWithValue(EventId, Milliseconds);
 #endif

--- a/Source/ProjectAtlantis/Private/Analytics/ScenePerformanceAnalyticsSubsystem.cpp
+++ b/Source/ProjectAtlantis/Private/Analytics/ScenePerformanceAnalyticsSubsystem.cpp
@@ -35,41 +35,54 @@ void UScenePerformanceAnalyticsSubsystem::Initialize(FSubsystemCollectionBase& C
 	}
 #endif
 
-	PreLoadMapHandle = FCoreUObjectDelegates::PreLoadMapWithContext.AddUObject (this, &UScenePerformanceAnalyticsSubsystem::HandlePreLoadMap);
-	PostLoadMapHandle = FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject (this, &UScenePerformanceAnalyticsSubsystem::HandlePostLoadMap);
-	WorldPostActorTickHandle = FWorldDelegates::OnWorldPostActorTick.AddUObject(this, &UScenePerformanceAnalyticsSubsystem::HandleWorldPostActorTick);
+	PreLoadMapHandle = FCoreUObjectDelegates::PreLoadMapWithContext.AddUObject(this, &UScenePerformanceAnalyticsSubsystem::OnPreLoadMap);
+	PostLoadMapHandle = FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject(this, &UScenePerformanceAnalyticsSubsystem::OnPostLoadMap);
+	WorldPostActorTickHandle = FWorldDelegates::OnWorldPostActorTick.AddUObject(this, &UScenePerformanceAnalyticsSubsystem::OnWorldPostActorTick);
 
 	if (const UWorld* World = GetGameInstance() ? GetGameInstance()->GetWorld() : nullptr)
+	{
 		CurrentSceneName = GetSceneName(World);
-
+	}
 }
 
 void UScenePerformanceAnalyticsSubsystem::Deinitialize()
 {
 	if (PreLoadMapHandle.IsValid())
+	{
 		FCoreUObjectDelegates::PreLoadMapWithContext.Remove(PreLoadMapHandle);
+	}
 
 	if (PostLoadMapHandle.IsValid())
+	{
 		FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(PostLoadMapHandle);
+	}
 
 	if (WorldPostActorTickHandle.IsValid())
+	{
 		FWorldDelegates::OnWorldPostActorTick.Remove(WorldPostActorTickHandle);
+	}
 
 	Super::Deinitialize();
 }
 
-void UScenePerformanceAnalyticsSubsystem::HandlePreLoadMap(const FWorldContext& WorldContext, const FString& MapName)
+void UScenePerformanceAnalyticsSubsystem::OnPreLoadMap(const FWorldContext& WorldContext, const FString& MapName)
 {
 	if (WorldContext.OwningGameInstance != GetGameInstance())
+	{
 		return;
+	}
 
 	const UWorld* CurrentWorld = WorldContext.World();
 	FromSceneName = GetSceneName(CurrentWorld);
 
 	if (!bStartupReported)
+	{
 		FromSceneName = TEXT("Startup");
+	}
 	else if (FromSceneName.IsEmpty())
+	{
 		FromSceneName = CurrentSceneName;
+	}
 
 	ToSceneName = GetSceneName(MapName);
 	LoadStartSeconds = FPlatformTime::Seconds();
@@ -81,25 +94,31 @@ void UScenePerformanceAnalyticsSubsystem::HandlePreLoadMap(const FWorldContext& 
 	UE_LOG(LogScenePerformanceAnalytics, Display, TEXT("Scene load started: %s -> %s"), FromSceneName.IsEmpty() ? TEXT("Startup") : *FromSceneName, *ToSceneName);
 }
 
-void UScenePerformanceAnalyticsSubsystem::HandlePostLoadMap(UWorld* LoadedWorld)
+void UScenePerformanceAnalyticsSubsystem::OnPostLoadMap(UWorld* LoadedWorld)
 {
 	if (!IsTrackedWorld(LoadedWorld))
+	{
 		return;
+	}
 
 	CurrentSceneName = GetSceneName(LoadedWorld);
 
 	if (!bLoadInProgress)
+	{
 		return;
+	}
 
 	LoadCompleteSeconds = FPlatformTime::Seconds();
 	PendingWorld = LoadedWorld;
 	bWaitingForFirstTick = true;
 }
 
-void UScenePerformanceAnalyticsSubsystem::HandleWorldPostActorTick(UWorld* World, ELevelTick TickType, float DeltaSeconds)
+void UScenePerformanceAnalyticsSubsystem::OnWorldPostActorTick(UWorld* World, const ELevelTick TickType, const float DeltaSeconds)
 {
 	if (!IsTrackedWorld(World))
+	{
 		return;
+	}
 
 	const double NowSeconds = FPlatformTime::Seconds();
 	const FString SceneName = GetSceneName(World);
@@ -113,7 +132,9 @@ void UScenePerformanceAnalyticsSubsystem::HandleWorldPostActorTick(UWorld* World
 	}
 
 	if (!bLoadInProgress || !bWaitingForFirstTick || PendingWorld.Get() != World)
+	{
 		return;
+	}
 
 	const FString LoadedSceneName = ToSceneName.IsEmpty() ? SceneName : ToSceneName;
 	const float MapLoadMilliseconds = static_cast<float>((LoadCompleteSeconds - LoadStartSeconds) * 1000.0);
@@ -122,10 +143,17 @@ void UScenePerformanceAnalyticsSubsystem::HandleWorldPostActorTick(UWorld* World
 	SubmitTiming(FString::Printf(TEXT("Performance:SceneReady:%s"), *LoadedSceneName), SceneReadyMilliseconds);
 
 	if (!FromSceneName.IsEmpty())
+	{
 		SubmitTiming(FString::Printf(TEXT("Performance:Transition:%s:%s"), *FromSceneName, *LoadedSceneName), SceneReadyMilliseconds);
+	}
 
-	UE_LOG(LogScenePerformanceAnalytics, Display, TEXT("Scene ready: %s -> %s | map load %.2f ms | ready %.2f ms"),
-		FromSceneName.IsEmpty() ? TEXT("Startup") : *FromSceneName,	*LoadedSceneName, MapLoadMilliseconds, SceneReadyMilliseconds);
+	UE_LOG(LogScenePerformanceAnalytics,
+		Display,
+		TEXT("Scene ready: %s -> %s | map load %.2f ms | ready %.2f ms"),
+		FromSceneName.IsEmpty() ? TEXT("Startup") : *FromSceneName,
+		*LoadedSceneName,
+		MapLoadMilliseconds,
+		SceneReadyMilliseconds);
 
 	CurrentSceneName = LoadedSceneName;
 	FromSceneName.Reset();
@@ -142,15 +170,19 @@ bool UScenePerformanceAnalyticsSubsystem::IsTrackedWorld(const UWorld* World) co
 	return World && World->IsGameWorld() && World->GetGameInstance() == GetGameInstance();
 }
 
-void UScenePerformanceAnalyticsSubsystem::SubmitTiming(const FString& EventId, float Milliseconds) const
+void UScenePerformanceAnalyticsSubsystem::SubmitTiming(const FString& EventId, const float Milliseconds) const
 {
 	if (EventId.IsEmpty() || Milliseconds < 0.0f)
+	{
 		return;
+	}
 
 #if !WITH_EDITOR
 
 	if (UGameAnalytics* GameAnalytics = UGameAnalytics::GetInstance())
+	{
 		GameAnalytics->AddDesignEventWithValue(EventId, Milliseconds);
+	}
 #endif
 }
 
@@ -162,7 +194,9 @@ FString UScenePerformanceAnalyticsSubsystem::GetSceneName(const UWorld* World)
 FString UScenePerformanceAnalyticsSubsystem::GetSceneName(const FString& MapName)
 {
 	if (MapName.IsEmpty())
+	{
 		return FString();
+	}
 
 	FString ShortName = FPackageName::GetShortName(MapName);
 	ShortName = UWorld::RemovePIEPrefix(ShortName, nullptr);
@@ -190,7 +224,9 @@ FString UScenePerformanceAnalyticsSubsystem::SanitizeEventSegment(const FString&
 	}
 
 	if (Sanitized.IsEmpty())
+	{
 		Sanitized = TEXT("Unknown");
+	}
 
 	// GameAnalytics limits each event hierarchy segment to 32 characters.
 	// Left(32) truncates longer map/scene names so generated event IDs stay within that limit instead of relying on GameAnalytics to truncate them after submission.

--- a/Source/ProjectAtlantis/Private/Analytics/ScenePerformanceAnalyticsSubsystem.cpp
+++ b/Source/ProjectAtlantis/Private/Analytics/ScenePerformanceAnalyticsSubsystem.cpp
@@ -1,0 +1,175 @@
+#include "Analytics/ScenePerformanceAnalyticsSubsystem.h"
+
+#include "Engine/Engine.h"
+#include "Engine/World.h"
+#include "GameAnalytics.h"
+#include "HAL/PlatformTime.h"
+#include "Misc/PackageName.h"
+#include "UObject/UObjectGlobals.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogScenePerformanceAnalytics, Log, All);
+
+void UScenePerformanceAnalyticsSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+	GameInstanceStartSeconds = FPlatformTime::Seconds();
+	PreLoadMapHandle = FCoreUObjectDelegates::PreLoadMapWithContext.AddUObject (this, &UScenePerformanceAnalyticsSubsystem::HandlePreLoadMap);
+	PostLoadMapHandle = FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject (this, &UScenePerformanceAnalyticsSubsystem::HandlePostLoadMap);
+	WorldPostActorTickHandle = FWorldDelegates::OnWorldPostActorTick.AddUObject(this, &UScenePerformanceAnalyticsSubsystem::HandleWorldPostActorTick);
+
+	if (const UWorld* World = GetGameInstance() ? GetGameInstance()->GetWorld() : nullptr)
+		CurrentSceneName = GetSceneName(World);
+
+}
+
+void UScenePerformanceAnalyticsSubsystem::Deinitialize()
+{
+	if (PreLoadMapHandle.IsValid())
+		FCoreUObjectDelegates::PreLoadMapWithContext.Remove(PreLoadMapHandle);
+
+	if (PostLoadMapHandle.IsValid())
+		FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(PostLoadMapHandle);
+
+	if (WorldPostActorTickHandle.IsValid())
+		FWorldDelegates::OnWorldPostActorTick.Remove(WorldPostActorTickHandle);
+
+	Super::Deinitialize();
+}
+
+void UScenePerformanceAnalyticsSubsystem::HandlePreLoadMap(const FWorldContext& WorldContext, const FString& MapName)
+{
+	if (WorldContext.OwningGameInstance != GetGameInstance())
+		return;
+
+	const UWorld* CurrentWorld = WorldContext.World();
+	FromSceneName = GetSceneName(CurrentWorld);
+
+	if (!bStartupReported)
+		FromSceneName = TEXT("Startup");
+	else if (FromSceneName.IsEmpty())
+		FromSceneName = CurrentSceneName;
+
+	ToSceneName = GetSceneName(MapName);
+	LoadStartSeconds = FPlatformTime::Seconds();
+	LoadCompleteSeconds = 0.0;
+	PendingWorld.Reset();
+	bLoadInProgress = true;
+	bWaitingForFirstTick = false;
+
+	UE_LOG(LogScenePerformanceAnalytics, Display, TEXT("Scene load started: %s -> %s"), FromSceneName.IsEmpty() ? TEXT("Startup") : *FromSceneName, *ToSceneName);
+}
+
+void UScenePerformanceAnalyticsSubsystem::HandlePostLoadMap(UWorld* LoadedWorld)
+{
+	if (!IsTrackedWorld(LoadedWorld))
+		return;
+
+	CurrentSceneName = GetSceneName(LoadedWorld);
+
+	if (!bLoadInProgress)
+		return;
+
+	LoadCompleteSeconds = FPlatformTime::Seconds();
+	PendingWorld = LoadedWorld;
+	bWaitingForFirstTick = true;
+}
+
+void UScenePerformanceAnalyticsSubsystem::HandleWorldPostActorTick(UWorld* World, ELevelTick TickType, float DeltaSeconds)
+{
+	if (!IsTrackedWorld(World))
+		return;
+
+	const double NowSeconds = FPlatformTime::Seconds();
+	const FString SceneName = GetSceneName(World);
+
+	if (!bStartupReported)
+	{
+		bStartupReported = true;
+		const float StartupMilliseconds = static_cast<float>((NowSeconds - GameInstanceStartSeconds) * 1000.0);
+		SubmitTiming(FString::Printf(TEXT("Performance:Startup:%s"), *SceneName), StartupMilliseconds);
+		UE_LOG(LogScenePerformanceAnalytics, Display, TEXT("Initial scene ready: %s | startup %.2f ms"), *SceneName, StartupMilliseconds);
+	}
+
+	if (!bLoadInProgress || !bWaitingForFirstTick || PendingWorld.Get() != World)
+		return;
+
+	const FString LoadedSceneName = ToSceneName.IsEmpty() ? SceneName : ToSceneName;
+	const float MapLoadMilliseconds = static_cast<float>((LoadCompleteSeconds - LoadStartSeconds) * 1000.0);
+	const float SceneReadyMilliseconds = static_cast<float>((NowSeconds - LoadStartSeconds) * 1000.0);
+	SubmitTiming(FString::Printf(TEXT("Performance:MapLoad:%s"), *LoadedSceneName), MapLoadMilliseconds);
+	SubmitTiming(FString::Printf(TEXT("Performance:SceneReady:%s"), *LoadedSceneName), SceneReadyMilliseconds);
+
+	if (!FromSceneName.IsEmpty())
+		SubmitTiming(FString::Printf(TEXT("Performance:Transition:%s:%s"), *FromSceneName, *LoadedSceneName), SceneReadyMilliseconds);
+
+	UE_LOG(LogScenePerformanceAnalytics, Display, TEXT("Scene ready: %s -> %s | map load %.2f ms | ready %.2f ms"),
+		FromSceneName.IsEmpty() ? TEXT("Startup") : *FromSceneName,	*LoadedSceneName, MapLoadMilliseconds, SceneReadyMilliseconds);
+
+	CurrentSceneName = LoadedSceneName;
+	FromSceneName.Reset();
+	ToSceneName.Reset();
+	PendingWorld.Reset();
+	bLoadInProgress = false;
+	bWaitingForFirstTick = false;
+	LoadStartSeconds = 0.0;
+	LoadCompleteSeconds = 0.0;
+}
+
+bool UScenePerformanceAnalyticsSubsystem::IsTrackedWorld(const UWorld* World) const
+{
+	return World && World->IsGameWorld() && World->GetGameInstance() == GetGameInstance();
+}
+
+void UScenePerformanceAnalyticsSubsystem::SubmitTiming(const FString& EventId, float Milliseconds) const
+{
+	if (EventId.IsEmpty() || Milliseconds < 0.0f)
+		return;
+
+#if !WITH_EDITOR
+	if (UGameAnalytics* GameAnalytics = UGameAnalytics::GetInstance())
+		GameAnalytics->AddDesignEventWithValue(EventId, Milliseconds);
+#endif
+}
+
+FString UScenePerformanceAnalyticsSubsystem::GetSceneName(const UWorld* World)
+{
+	return World ? GetSceneName(World->GetMapName()) : FString();
+}
+
+FString UScenePerformanceAnalyticsSubsystem::GetSceneName(const FString& MapName)
+{
+	if (MapName.IsEmpty())
+		return FString();
+
+	FString ShortName = FPackageName::GetShortName(MapName);
+	ShortName = UWorld::RemovePIEPrefix(ShortName, nullptr);
+	return SanitizeEventSegment(ShortName);
+}
+
+FString UScenePerformanceAnalyticsSubsystem::SanitizeEventSegment(const FString& Segment)
+{
+	FString Sanitized;
+	Sanitized.Reserve(Segment.Len());
+
+	for (const TCHAR Character : Segment)
+	{
+		const bool bAllowed = FChar::IsAlnum(Character)
+			|| Character == TEXT('_')
+			|| Character == TEXT('-')
+			|| Character == TEXT('.')
+			|| Character == TEXT(' ')
+			|| Character == TEXT('(')
+			|| Character == TEXT(')')
+			|| Character == TEXT('!')
+			|| Character == TEXT('?');
+
+		Sanitized.AppendChar(bAllowed ? Character : TEXT('_'));
+	}
+
+	if (Sanitized.IsEmpty())
+		Sanitized = TEXT("Unknown");
+
+	// GameAnalytics limits each event hierarchy segment to 32 characters.
+	// Left(32) truncates longer map/scene names so generated event IDs stay within that limit instead of relying on GameAnalytics to truncate them after submission.
+	return Sanitized.Left(32);
+}

--- a/Source/ProjectAtlantis/ProjectAtlantis.Build.cs
+++ b/Source/ProjectAtlantis/ProjectAtlantis.Build.cs
@@ -10,7 +10,7 @@ public class ProjectAtlantis : ModuleRules
 	
 		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EngineSettings" });
 
-		PrivateDependencyModuleNames.AddRange(new string[] { "GameAnalytics" });
+		PrivateDependencyModuleNames.AddRange(new string[] { "Analytics", "GameAnalytics" });
 
 		PrivateIncludePathModuleNames.AddRange(new string[] { "GameAnalytics" });
 

--- a/Source/ProjectAtlantis/Public/Analytics/ScenePerformanceAnalyticsSubsystem.h
+++ b/Source/ProjectAtlantis/Public/Analytics/ScenePerformanceAnalyticsSubsystem.h
@@ -22,12 +22,12 @@ public:
 	virtual void Deinitialize() override;
 
 private:
-	void HandlePreLoadMap(const FWorldContext& WorldContext, const FString& MapName);
-	void HandlePostLoadMap(UWorld* LoadedWorld);
-	void HandleWorldPostActorTick(UWorld* World, ELevelTick TickType, float DeltaSeconds);
+	void OnPreLoadMap(const FWorldContext& WorldContext, const FString& MapName);
+	void OnPostLoadMap(UWorld* LoadedWorld);
+	void OnWorldPostActorTick(UWorld* World, const ELevelTick TickType, const float DeltaSeconds);
 
 	bool IsTrackedWorld(const UWorld* World) const;
-	void SubmitTiming(const FString& EventId, float Milliseconds) const;
+	void SubmitTiming(const FString& EventId, const float Milliseconds) const;
 
 	static FString GetSceneName(const UWorld* World);
 	static FString GetSceneName(const FString& MapName);

--- a/Source/ProjectAtlantis/Public/Analytics/ScenePerformanceAnalyticsSubsystem.h
+++ b/Source/ProjectAtlantis/Public/Analytics/ScenePerformanceAnalyticsSubsystem.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/EngineBaseTypes.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "ScenePerformanceAnalyticsSubsystem.generated.h"
+
+class UWorld;
+struct FWorldContext;
+
+/**
+ * Automatically tracks map loading, scene readiness, scene transitions, and initial startup timing.
+ * The subsystem is created once per GameInstance and requires no per-level setup.
+ */
+UCLASS()
+class PROJECTATLANTIS_API UScenePerformanceAnalyticsSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+
+private:
+	void HandlePreLoadMap(const FWorldContext& WorldContext, const FString& MapName);
+	void HandlePostLoadMap(UWorld* LoadedWorld);
+	void HandleWorldPostActorTick(UWorld* World, ELevelTick TickType, float DeltaSeconds);
+
+	bool IsTrackedWorld(const UWorld* World) const;
+	void SubmitTiming(const FString& EventId, float Milliseconds) const;
+
+	static FString GetSceneName(const UWorld* World);
+	static FString GetSceneName(const FString& MapName);
+	static FString SanitizeEventSegment(const FString& Segment);
+
+	FDelegateHandle PreLoadMapHandle;
+	FDelegateHandle PostLoadMapHandle;
+	FDelegateHandle WorldPostActorTickHandle;
+
+	double GameInstanceStartSeconds = 0.0;
+	double LoadStartSeconds = 0.0;
+	double LoadCompleteSeconds = 0.0;
+
+	FString CurrentSceneName;
+	FString FromSceneName;
+	FString ToSceneName;
+
+	TWeakObjectPtr<UWorld> PendingWorld;
+
+	bool bLoadInProgress = false;
+	bool bWaitingForFirstTick = false;
+	bool bStartupReported = false;
+};


### PR DESCRIPTION
# Summary

Adds automatic scene performance analytics in C++ using a `UGameInstanceSubsystem`.

The subsystem starts the configured GameAnalytics session globally in non-editor builds, so analytics no longer depend on `Lvl_ThirdPerson` or any specific startup level.

It tracks:
- Initial scene readiness/startup time
- Map load time
- Time until the loaded scene's first actor tick
- Scene-to-scene transition time

Implementation is in:
- `Source/ProjectAtlantis/Public/Analytics/ScenePerformanceAnalyticsSubsystem.h`
- `Source/ProjectAtlantis/Private/Analytics/ScenePerformanceAnalyticsSubsystem.cpp`

The old `Lvl_ThirdPerson` Level Blueprint `Start Session` chain was removed because session initialization is now handled globally in C++.

This replaces PR #112 so the work is submitted from an in-repo branch per the project Git hygiene guidelines.

# Related Issue 

Closes #118 

# Testing

- [x] Built successfully
- [x] Tested locally
- [x] No known regressions

# Checklist

- [x] PR title accurately summarizes the final change
- [x] Summary reflects what was actually implemented
- [x] Follows the project style guide
- [x] Documentation updated if needed
- [x] No unrelated changes included
- [x] Ready for review

# Analytics Notes

## Adding Analytics in C++

The GameAnalytics session is initialized globally in packaged builds, so individual gameplay systems do not need to start their own session.

For a design event with a numeric value:

```cpp
if (UGameAnalytics* GameAnalytics = UGameAnalytics::GetInstance())
{
    GameAnalytics->AddDesignEventWithValue(TEXT("Category:EventName"), Value);
}
```

For an event without a value:

```cpp
if (UGameAnalytics* GameAnalytics = UGameAnalytics::GetInstance())
{
    GameAnalytics->AddDesignEvent(TEXT("Category:EventName"));
}
```

GameAnalytics design event IDs can use colon-separated segments to organize related events, for example:

- Combat:EnemyDefeated:Boss
- Gameplay:BuildingEntered:CoralLab
- Performance:MapLoad:Lvl_ThirdPerson

## Adding Analytics in Blueprints

Blueprints can use the existing analytics/GameAnalytics nodes to submit individual events.

For normal gameplay analytics:

- Use the appropriate event-recording node for the event being tracked.
- Use a consistent event name or hierarchy, matching the C++ naming convention where practical.
- Include a numeric value when the event needs one.
- Blueprints should not call `Start Session`; session initialization is handled globally in C++, regardless of which map starts first.

